### PR TITLE
Update to use new reactphp/async package instead of clue/reactphp-block

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,15 +422,13 @@ $promise = Queue::any(10, $jobs, array($browser, 'get'));
 #### Blocking
 
 As stated above, this library provides you a powerful, async API by default.
-If, however, you want to integrate this into your traditional, blocking
-environment, you may want to look into also using
-[clue/reactphp-block](https://github.com/clue/reactphp-block).
 
-The resulting blocking code that awaits a number of concurrent HTTP requests
-could look something like this:
+You can also integrate this into your traditional, blocking environment by using
+[reactphp/async](https://github.com/reactphp/async). This allows you to simply
+await async HTTP requests like this:
 
 ```php
-use Clue\React\Block;
+use function React\Async\await;
 
 $browser = new React\Http\Browser();
 
@@ -439,7 +437,7 @@ $promise = Queue::all(3, $urls, function ($url) use ($browser) {
 });
 
 try {
-    $responses = Block\await($promise, $loop);
+    $responses = await($promise);
     // responses successfully received
 } catch (Exception $e) {
     // an error occured while performing the requests
@@ -450,6 +448,8 @@ Similarly, you can also wrap this in a function to provide a simple API and hide
 all the async details from the outside:
 
 ```php
+use function React\Async\await; 
+
 /**
  * Concurrently downloads all the given URIs
  *
@@ -465,12 +465,13 @@ function download(array $uris)
         return $browser->get($uri);
     });
 
-    return Clue\React\Block\await($promise, $loop);
+    return await($promise);
 }
 ```
 
-Please refer to [clue/reactphp-block](https://github.com/clue/reactphp-block#readme)
-for more details.
+This is made possible thanks to fibers available in PHP 8.1+ and our
+compatibility API that also works on all supported PHP versions.
+Please refer to [reactphp/async](https://github.com/reactphp/async#readme) for more details.
 
 > Keep in mind that returning an array of response messages means that the whole
   response body has to be kept in memory.

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "react/promise": "^3 || ^2.2.1 || ^1.2.1"
     },
     "require-dev": {
-        "clue/block-react": "^1.5",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
+        "react/async": "^4 || ^3 || ^2",
         "react/event-loop": "^1.2",
         "react/http": "^1.8"
     }

--- a/examples/11-http-blocking.php
+++ b/examples/11-http-blocking.php
@@ -1,8 +1,5 @@
 <?php
 
-use Clue\React\Block;
-use React\EventLoop\Loop;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 // list of all URLs you want to download
@@ -33,7 +30,7 @@ function download(array $urls)
         );
     });
 
-    return Block\await($promise, Loop::get());
+    return React\Async\await($promise);
 }
 
 $responses = download($urls);


### PR DESCRIPTION
See https://github.com/reactphp/async

Builds on top of #31 

Ref: https://github.com/clue/reactphp-block/pull/67,  https://github.com/clue/reactphp-block/issues/68 and https://github.com/reactphp/http/pull/464