### PR TITLE
Support PHP 8.2, refactor queuing logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.2
           - 8.1
           - 8.0
           - 7.4


### PR DESCRIPTION
This changeset refactors the queuing logic to avoid using dynamic properties to improve support for PHP 8.2.

Resolves / closes #35 
Supersedes / closes #36 
Builds on top of #42, #39 and #37