### PR TITLE
Run tests on PHP 8.5 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -26,7 +27,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/promise": "^3 || ^2.2.1 || ^1.2.1"
+        "react/promise": "^3.3 || ^2.2.1 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36",
-        "react/async": "^4 || ^3 || ^2",
-        "react/event-loop": "^1.2",
+        "react/async": "^4.3 || ^3 || ^2",
+        "react/event-loop": "^1.6",
         "react/http": "^1.8"
     },
     "autoload": {


### PR DESCRIPTION
This changeset updates the test environment to run the test suite on PHP 8.5.

Builds on top of #53, #50, https://github.com/reactphp/event-loop/pull/282, https://github.com/reactphp/promise/pull/264, and https://github.com/clue/framework-x/pull/297